### PR TITLE
devfsadm directory should also be created in the install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ install: world
 	@cp kvm.conf $(DESTDIR)/usr/kernel/drv
 	@mkdir -p $(DESTDIR)/usr/lib/mdb/kvm/amd64
 	@cp kvm.so $(DESTDIR)/usr/lib/mdb/kvm/amd64
+	@mkdir -p $(DESTDIR)/usr/lib/devfsadm/
 	@cp JOY_kvm_link.so $(DESTDIR)/usr/lib/devfsadm/linkmod
 
 check:


### PR DESCRIPTION
Without this line I hit an error because my DESTDIR is not '/'.
