### PR TITLE
Don't use the obsolete -fno-dwarf2-indirect-strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,14 +107,12 @@ KERNEL_CFLAGS = \
 	-Wpointer-arith \
 	-gdwarf-2 \
 	-std=gnu99 \
-	-fno-dwarf2-indirect-strings \
 	-mno-red-zone
 
 USER_CFLAGS = \
 	-finline \
 	-gdwarf-2 \
 	-std=gnu89 \
-	-fno-dwarf2-indirect-strings \
 	-Wno-missing-braces \
 	-Wno-sign-compare \
 	-Wno-parentheses \


### PR DESCRIPTION
-fno-dwarf2-indirect-strings was necessary to prevent _any_ form of
relocation in a debug section because the libdwarf used by the CTF tools
used to be very, very, very old.  The updated libdwarf that's been used
for a quite a while now is immune to this, and the flag was removed from
the patched compiler.

/cc @wesolows @rmustacc
