### PR TITLE
Reset local APIC from VCPU reset, set base and LDR

### DIFF
--- a/kvm_x86.c
+++ b/kvm_x86.c
@@ -3516,7 +3516,6 @@ __vcpu_run(struct kvm_vcpu *vcpu)
 	if (vcpu->arch.mp_state == KVM_MP_STATE_SIPI_RECEIVED) {
 		cmn_err(CE_CONT, "!vcpu %d received sipi with vector # %x\n",
 		    vcpu->vcpu_id, vcpu->arch.sipi_vector);
-		kvm_lapic_reset(vcpu);
 		r = kvm_arch_vcpu_reset(vcpu);
 		if (r)
 			return (r);
@@ -4690,6 +4689,7 @@ free_vcpu:
 int
 kvm_arch_vcpu_reset(struct kvm_vcpu *vcpu)
 {
+	kvm_lapic_reset(vcpu);
 	vcpu->arch.nmi_pending = 0;
 	vcpu->arch.nmi_injected = 0;
 


### PR DESCRIPTION
Consolidate `kvm_lapic_reset()` calls to the beginning of `kvm_arch_vcpu_reset`,  and make `kvm_lapic_reset` set the correct local APIC base address and ID value in the LDR.